### PR TITLE
feat: add Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,16 @@
-# Creates a Docker image that is ready to execute tes compliance suite
+# Creates a Docker image that is ready to execute tes compliance suite                                                                                     Dockerfile                                                                                                 # Creates a Docker image that is ready to execute tes compliance suite
 
-FROM ubuntu:latest AS build-env
+FROM python:3.8-slim AS build-env
+
 WORKDIR /app
 
 # Install TES Compliance suite dependencies
 # Git is needed for the clone and jq is helpful with parsing results if needed
-RUN apt update
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt install -y software-properties-common
-
-RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt update
-RUN apt -y install python3.8 python3.8-distutils python3-pip git jq
+RUN apt -y install git jq
 
-RUN git clone https://github.com/elixir-cloud-aai/tes-compliance-suite.git 
+RUN git clone https://github.com/elixir-cloud-aai/tes-compliance-suite.git
 
 # Install TES Compliance suite
 WORKDIR /app/tes-compliance-suite

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Creates a Docker image that is ready to execute tes compliance suite                                                                                     Dockerfile                                                                                                 # Creates a Docker image that is ready to execute tes compliance suite
+# Creates a Docker image that is ready to execute tes compliance suite
 
 FROM python:3.8-slim AS build-env
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
-# Creates a docker image that is ready to execute tes compliance suite
+# Creates a Docker image that is ready to execute tes compliance suite
 
 FROM ubuntu:latest AS build-env
 WORKDIR /app
 
-# Install Tes Compliance suite dependencies
+# Install TES Compliance suite dependencies
 # Git is needed for the clone and jq is helpful with parsing results if needed
 RUN apt update
 ENV DEBIAN_FRONTEND=noninteractive
@@ -15,14 +15,14 @@ RUN apt-get -y install python3.8 python3.8-distutils python3-pip git jq
 
 RUN git clone https://github.com/elixir-cloud-aai/tes-compliance-suite.git 
 
-# Install Tes Compliance suite
+# Install TES Compliance suite
 WORKDIR /app/tes-compliance-suite
 RUN python3.8 setup.py install
 
 # Precreate results directory
 RUN mkdir results
 
-# Cope over specific instruction around how to run the tests
+# Copy over specific instructions around how to run the tests
 COPY entrypoint.sh /app/tes-compliance-suite/entrypoint.sh
 
 ENTRYPOINT ["/bin/bash", "entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir results
 # Copy over specific instructions around how to run the tests
 COPY entrypoint.sh /app/tes-compliance-suite/entrypoint.sh
 
-# If using entryoint script with no edits, set TES endpoint url here
+# If using entrpyoint script with no edits, set TES endpoint url here
 ENV TES_ENDPOINT_URL=http://localhost/
 
 ENTRYPOINT ["/bin/bash", "entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,28 @@
+# Creates a docker image that is ready to execute tes compliance suite
+
+FROM ubuntu:latest AS build-env
+WORKDIR /app
+
+# Install Tes Compliance suite dependencies
+# Git is needed for the clone and jq is helpful with parsing results if needed
+RUN apt update
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt install -y software-properties-common
+
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update
+RUN apt-get -y install python3.8 python3.8-distutils python3-pip git jq
+
+RUN git clone https://github.com/elixir-cloud-aai/tes-compliance-suite.git 
+
+# Install Tes Compliance suite
+WORKDIR /app/tes-compliance-suite
+RUN python3.8 setup.py install
+
+# Precreate results directory
+RUN mkdir results
+
+# Cope over specific instruction around how to run the tests
+COPY entrypoint.sh /app/tes-compliance-suite/entrypoint.sh
+
+ENTRYPOINT ["/bin/bash", "entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,8 +10,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt install -y software-properties-common
 
 RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get update
-RUN apt-get -y install python3.8 python3.8-distutils python3-pip git jq
+RUN apt update
+RUN apt -y install python3.8 python3.8-distutils python3-pip git jq
 
 RUN git clone https://github.com/elixir-cloud-aai/tes-compliance-suite.git 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,4 +25,7 @@ RUN mkdir results
 # Copy over specific instructions around how to run the tests
 COPY entrypoint.sh /app/tes-compliance-suite/entrypoint.sh
 
+# If using entryoint script with no edits, set TES endpoint url here
+ENV TES_ENDPOINT_URL=http://localhost/
+
 ENTRYPOINT ["/bin/bash", "entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# This file proves to be less useful if the url of the server never changes and all tests are always run
+# This file proves to be less useful if the url of the server never changes and all tests are always run.
 # If tests need to be run in a specific order
-# or only specific tests need to be run this file allows for that to be adjusted
+# or only specific tests need to be run this file allows for that to be adjusted.
 # If the server url is not constant it can be passed into as a variable
-# or if basic auth is used and a username/password are required to run the tests
+# or if basic auth is used and a username/password are required to run the tests.
 
 # example command below
 # tes-compliance-suite report --server <insert_url> --tag all --output_path results

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# This file proves to be less useful if the url of the server never changes and all tests are always run
+# If tests need to be run in a specific order
+# or only specific tests need to be run this file allows for that to be adjusted
+# If the server url is not constant it can be passed into as a variable
+# or if basic auth is used and a username/password are required to run the tests
+
+# example command below
+# tes-compliance-suite report --server <insert_url> --tag all --output_path results

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-# This file proves to be less useful if the url of the server never changes and all tests are always run.
-# If tests need to be run in a specific order
-# or only specific tests need to be run this file allows for that to be adjusted.
-# If the server url is not constant it can be passed into as a variable
-# or if basic auth is used and a username/password are required to run the tests.
-
-# example command below
-# tes-compliance-suite report --server <insert_url> --tag all --output_path results
+# expects 'TesEndpointUrl' to already be set, can be done in Dockerfile
+# default is set to localhost
+tes-compliance-suite report --server $TES_ENDPOINT_URL --tag all --output_path results

--- a/docs/utility.md
+++ b/docs/utility.md
@@ -96,4 +96,25 @@ path/to/python3.8/python setup.py install
 path/to/python3.8/Scripts/tes-compliance-suite report
 ```
 
+## Docker image
+
+The project has a [Dockerfile][dockerfile] that creates a ubuntu based container image ready to run tes-compliance-suite. It uses [entrypoint.sh][entrypoint] as an entrypoint, which is most useful if the url of the server changes each time the test suite is run or if only specific tests need to be run. Also, if the server requires basic authentication to connect to, entrypoint.sh can be edited to accept not just the endpoint url, but the username and password as well. 
+
+```base  
+http://$tesuser:$tespassword@$teshostname/
+```
+
+Currently the TES endpoint url in entrypoint.sh will grab the value from an enviormental variable in the image. However, entrypoint.sh gives flexibility to define how that value can be populated. For example, a file can be copied over to the image containing the endpoint url, username and password which could then be read and parsed to pass into tes-compliance suite. Refer to the example below. 
+
+```base  
+#!/bin/sh
+teshostname=$(jq -r '.TesHostname' TesCredentials.json)
+tesuser=$(jq -r '.TesUsername' TesCredentials.json)
+tespassword=$(jq -r '.TesPassword' TesCredentials.json)
+
+tes-compliance-suite report --server http://$tesuser:$tespassword@$teshostname/ --tag all --output_path results
+```
+
 [res-test-template]: ../tests/template/test_template.yml
+[dockerfile]: ../docker/Dockerfile
+[entrypoint]: ../docker/entrypoint.sh


### PR DESCRIPTION
Adding text from the email I had sent to @uniqueg for context below. 

I recently joined the Heath Futures org at Microsoft and have been working with Matt McLoughlin to add tes compliance suite to run as part of our integration test flow in [Microsoft/GA4GH-TES](https://github.com/microsoft/ga4gh-tes/pull/32), to do that I created a Dockerfile that generates a Docker image that is ready to execute tes compliance tests. Matt suggested reaching out to you to see if it would make sense to add this Dockerfile to the tes-compliance-suite repo since others may want to do something similar. 

Here is a [draft PR](https://github.com/microsoft/ga4gh-tes/pull/32) that has the docker file and corresponding entrypoint file included on our side – I have just been using this for testing so far. Let me know if you think this is something that would make sense to add to the tes-compliance-suite repo and if any changes are needed! Creating as a draft PR for now! 