### PR TITLE
feat: add semantic versioning

### DIFF
--- a/compliance_suite/cli.py
+++ b/compliance_suite/cli.py
@@ -20,7 +20,7 @@ def main() -> None:
 
 @main.command(help='Run TES compliance tests against the servers')
 @click.option('--server', '-s', help='server URL on which the compliance tests are run. Format - https://<url>/')
-@click.option('--version', '-v', help='TES version. Example - "v1.0"')
+@click.option('--version', '-v', help='TES version. Example - "1.0.0"')
 @click.option('--tag', '-t', multiple=True, help='Tag', default=['All'])
 @click.option('--output_path', '-o', help='path to output the JSON report')
 @click.option('--serve', default=False, is_flag=True, help='spin up a server')
@@ -38,8 +38,7 @@ def report(server: str,
 
     Args:
         server (str): The server URL on which the compliance suite will be run. Format - https://<url>/
-        version (str): The compliance suite will be run against this TES version.
-                       Default - Latest version. Example - "v1.0"
+        version (str): The compliance suite will be run against this TES version. Example - "1.0.0"
         tag (List[str]): The list of the tags for which the compliance suite will be run. Default - All
         output_path (str): The output path to store the JSON compliance report
         serve (bool): If true, runs a local server and displays the JSON report in webview
@@ -51,8 +50,7 @@ def report(server: str,
         raise Exception("No server provided. Please provide a server URL.")
 
     if version is None:
-        logger.info("No version provided. Latest version is used as default value.")
-        version = "v1.0"                    # Hardcode the latest version here. TODO - Future versions
+        raise Exception("No version provided. Please provide a version.")
 
     tag = [val.lower() for val in tag]      # Convert the tags into lowercase to allow case-insensitive tags
     logger.info(f"Input tag is - {tag}")

--- a/compliance_suite/constants/constants.py
+++ b/compliance_suite/constants/constants.py
@@ -13,13 +13,6 @@ from compliance_suite.models.v1_0_specs import (
     TesTaskMinimal,
 )
 
-# YAML Constants
-
-VERSION_INFO = {
-    'v1.0': 'v1',
-    'v1.1': 'v1'
-}
-
 # Utility Constants
 
 LOGGING_LEVEL = {

--- a/compliance_suite/functions/client.py
+++ b/compliance_suite/functions/client.py
@@ -59,7 +59,7 @@ class Client():
         for key in uri_params.keys():
             endpoint = endpoint.replace(f"{{{key}}}", uri_params[key])
 
-        version = "v" + version[0]  # Convert SemVer into Major API version
+        version = "v" + version.split(".")[0]  # Convert SemVer into Major API version
         base_url: str = str(server) + version + endpoint
         request_headers: dict = REQUEST_HEADERS[service]
         response = None
@@ -140,7 +140,7 @@ class Client():
             endpoint = endpoint.replace(f"{{{key}}}", uri_params[key])
 
         self.check_cancel = check_cancel_val
-        version = "v" + version[0]  # Convert SemVer into Major API version
+        version = "v" + version.split(".")[0]  # Convert SemVer into Major API version
         base_url: str = str(server) + version + endpoint
         request_headers: dict = REQUEST_HEADERS[service]
 

--- a/compliance_suite/functions/client.py
+++ b/compliance_suite/functions/client.py
@@ -59,6 +59,7 @@ class Client():
         for key in uri_params.keys():
             endpoint = endpoint.replace(f"{{{key}}}", uri_params[key])
 
+        version = "v" + version[0]  # Convert SemVer into Major API version
         base_url: str = str(server) + version + endpoint
         request_headers: dict = REQUEST_HEADERS[service]
         response = None
@@ -137,7 +138,9 @@ class Client():
 
         for key in uri_params.keys():
             endpoint = endpoint.replace(f"{{{key}}}", uri_params[key])
+
         self.check_cancel = check_cancel_val
+        version = "v" + version[0]  # Convert SemVer into Major API version
         base_url: str = str(server) + version + endpoint
         request_headers: dict = REQUEST_HEADERS[service]
 

--- a/compliance_suite/functions/client.py
+++ b/compliance_suite/functions/client.py
@@ -24,86 +24,56 @@ from compliance_suite.functions.log import logger
 class Client():
     """ This class is used to send REST requests to the provided server URL """
 
-    def __init__(self, service: str, server: str, version: str):
-        """ Initialize the Client object containing the server details
+    def __init__(self):
+        """ Initialize the Client object"""
 
-        Args:
-            service: The API service name
-            server: The server URL to send the request
-            version: The version of the deployed API service
-        """
-
-        self.service: str = service
-        self.server: str = server
-        self.version: str = self.parse_version(version)
-        self.request_headers: dict = REQUEST_HEADERS[service]
-        self.endpoint: str = ""
-        self.uri_params: Dict = {}
-        self.query_params: Dict = {}
-        self.operation: str = ""
-        self.request_body: str = ""
-        self.base_url: str = ""
         self.check_cancel = False   # Checks if the Cancel status is to be validated or not
 
-    @staticmethod
-    def parse_version(version: str) -> str:
-        """Parse the API version and convert into server URL specific version
-
-        Args:
-            version: The API version. Format - SemVer
-
-        Returns:
-            Transformed version to be set in API server URL
-        """
-
-        # Extract the major API version
-        return "v" + version.split(".")[0]
-
-    def set_endpoint_data(
+    def send_request(
             self,
+            service: str,
+            server: str,
+            version: str,
             endpoint: str,
             uri_params: Dict,
             query_params: Dict,
             operation: str,
             request_body: str
-    ) -> None:
-        """Sets the endpoint data
+    ) -> Response:
+        """ Sends the REST request to provided server
 
         Args:
-            endpoint: The endpoint of the given server
-            uri_params: URI parameters in the endpoint
-            query_params: The query parameters to be sent along with the request
-            operation: The HTTP operation for the endpoint
-            request_body: The request body for the request
+            service (str): The GA4GH service name (eg. TES)
+            server (str): The server URL to send the request
+            version (str): The version of the deployed server
+            endpoint (str): The endpoint of the given server
+            uri_params (dict): URI parameters in the endpoint
+            query_params (dict): The query parameters to be sent along with the request
+            operation (str): The HTTP operation for the endpoint
+            request_body (str): The request body for the request
+
+        Returns:
+            (Response): The response from the server is returned
         """
 
         for key in uri_params.keys():
             endpoint = endpoint.replace(f"{{{key}}}", uri_params[key])
-        self.endpoint = endpoint
-        self.base_url = str(self.server) + self.version + self.endpoint
-        self.uri_params = uri_params
-        self.query_params = query_params
-        self.operation = operation
-        self.request_body = request_body
 
-    def send_request(self) -> Response:
-        """ Sends the REST request to configured server
-        Returns:
-            The response from the server is returned
-        """
-
+        version = "v" + version[0]  # Convert SemVer into Major API version
+        base_url: str = str(server) + version + endpoint
+        request_headers: dict = REQUEST_HEADERS[service]
         response = None
-        logger.info(f"Sending {self.operation} request to {self.base_url}. Query Parameters - {self.query_params}")
+        logger.info(f"Sending {operation} request to {base_url}. Query Parameters - {query_params}")
         try:
-            if self.operation == "GET":
-                response = requests.get(self.base_url, headers=self.request_headers, params=self.query_params)
-            elif self.operation == "POST":
-                request_body = json.loads(self.request_body)
-                response = requests.post(self.base_url, headers=self.request_headers, json=request_body)
+            if operation == "GET":
+                response = requests.get(base_url, headers=request_headers, params=query_params)
+            elif operation == "POST":
+                request_body = json.loads(request_body)
+                response = requests.post(base_url, headers=request_headers, json=request_body)
             return response
         except OSError as err:
             raise TestRunnerException(name="OS Error",
-                                      message=f"Connection error to {self.operation} {self.base_url}",
+                                      message=f"Connection error to {operation} {base_url}",
                                       details=err)
 
     def check_poll(
@@ -137,36 +107,55 @@ class Client():
 
     def poll_request(
             self,
+            service: str,
+            server: str,
+            version: str,
+            endpoint: str,
+            uri_params: Dict,
+            query_params: Dict,
+            operation: str,
             polling_interval: int,
             polling_timeout: int,
             check_cancel_val: bool
     ) -> Response:
-        """ This function polls a request to configured server with given interval and timeout
+        """ This function polls a request to specified server with given interval and timeout
 
         Args:
-            polling_interval: The duration between polling
-            polling_timeout: The timeout for the polling request. Raises Timeout exception if exceeded
-            check_cancel_val: Bool to verify Cancel status or not
+            service (str): The GA4GH service name (eg. TES)
+            server (str): The server URL to send the request
+            version (str): The version of the deployed server
+            endpoint (str): The endpoint of the given server
+            uri_params (dict): URI parameters in the endpoint
+            query_params (dict): The query parameters to be sent along with the request
+            operation (str): The HTTP operation for the endpoint
+            polling_interval (int): The duration between polling
+            polling_timeout (int): The timeout for the polling request. Raises Timeout exception if exceeded
+            check_cancel_val (bool): Bool to verify Cancel status or not
 
         Returns:
-            The response from the server is returned
+            (Response): The response from the server is returned
         """
 
+        for key in uri_params.keys():
+            endpoint = endpoint.replace(f"{{{key}}}", uri_params[key])
+
         self.check_cancel = check_cancel_val
-        logger.info(f"Sending {self.operation} polling request to {self.base_url}."
-                    f" Query Parameters - {self.query_params}")
+        version = "v" + version[0]  # Convert SemVer into Major API version
+        base_url: str = str(server) + version + endpoint
+        request_headers: dict = REQUEST_HEADERS[service]
+
+        logger.info(f"Sending {operation} polling request to {base_url}. Query Parameters - {query_params}")
 
         try:
-            response = polling2.poll(
-                lambda: requests.get(self.base_url, headers=self.request_headers, params=self.query_params),
-                step=polling_interval, timeout=polling_timeout, check_success=self.check_poll
-            )
+            response = polling2.poll(lambda: requests.get(base_url, headers=request_headers, params=query_params),
+                                     step=polling_interval, timeout=polling_timeout,
+                                     check_success=self.check_poll)
             return response
         except polling2.TimeoutException:
             raise TestFailureException(name="Polling Timeout Exception",
-                                       message=f"Polling timeout for {self.operation} {self.base_url}",
+                                       message=f"Polling timeout for {operation} {base_url}",
                                        details=None)
         except OSError as err:
             raise TestRunnerException(name="OS Error",
-                                      message=f"Connection error to {self.operation} {self.base_url}",
+                                      message=f"Connection error to {operation} {base_url}",
                                       details=err)

--- a/compliance_suite/test_runner.py
+++ b/compliance_suite/test_runner.py
@@ -250,19 +250,24 @@ class TestRunner():
             request_body: str = self.job_data["request_body"]
             self.validate_request_body(request_body)
 
-        client = Client(service=self.service, server=self.server, version=self.version)
-        client.set_endpoint_data(endpoint=self.job_data["endpoint"], uri_params=uri_params, query_params=query_params,
-                                 operation=self.job_data["operation"], request_body=request_body)
+        client = Client()
 
         if "polling" in self.job_data.keys():
+
             check_cancel: bool = False
             if "env_vars" in self.job_data.keys() and "check_cancel" in self.job_data["env_vars"].keys():
                 check_cancel = self.job_data["env_vars"]["check_cancel"]
 
-            response = client.poll_request(polling_interval=self.job_data["polling"]["interval"],
+            response = client.poll_request(service=self.service, server=self.server, version=self.version,
+                                           endpoint=self.job_data["endpoint"], uri_params=uri_params,
+                                           query_params=query_params, operation=self.job_data["operation"],
+                                           polling_interval=self.job_data["polling"]["interval"],
                                            polling_timeout=self.job_data["polling"]["timeout"],
                                            check_cancel_val=check_cancel)
         else:
-            response = client.send_request()
+            response = client.send_request(service=self.service, server=self.server, version=self.version,
+                                           endpoint=self.job_data["endpoint"], uri_params=uri_params,
+                                           query_params=query_params, operation=self.job_data["operation"],
+                                           request_body=request_body)
 
         self.validate_response(response)

--- a/compliance_suite/test_runner.py
+++ b/compliance_suite/test_runner.py
@@ -250,24 +250,19 @@ class TestRunner():
             request_body: str = self.job_data["request_body"]
             self.validate_request_body(request_body)
 
-        client = Client()
+        client = Client(service=self.service, server=self.server, version=self.version)
+        client.set_endpoint_data(endpoint=self.job_data["endpoint"], uri_params=uri_params, query_params=query_params,
+                                 operation=self.job_data["operation"], request_body=request_body)
 
         if "polling" in self.job_data.keys():
-
             check_cancel: bool = False
             if "env_vars" in self.job_data.keys() and "check_cancel" in self.job_data["env_vars"].keys():
                 check_cancel = self.job_data["env_vars"]["check_cancel"]
 
-            response = client.poll_request(service=self.service, server=self.server, version=self.version,
-                                           endpoint=self.job_data["endpoint"], uri_params=uri_params,
-                                           query_params=query_params, operation=self.job_data["operation"],
-                                           polling_interval=self.job_data["polling"]["interval"],
+            response = client.poll_request(polling_interval=self.job_data["polling"]["interval"],
                                            polling_timeout=self.job_data["polling"]["timeout"],
                                            check_cancel_val=check_cancel)
         else:
-            response = client.send_request(service=self.service, server=self.server, version=self.version,
-                                           endpoint=self.job_data["endpoint"], uri_params=uri_params,
-                                           query_params=query_params, operation=self.job_data["operation"],
-                                           request_body=request_body)
+            response = client.send_request()
 
         self.validate_response(response)

--- a/compliance_suite/test_runner.py
+++ b/compliance_suite/test_runner.py
@@ -15,10 +15,7 @@ from ga4gh.testbed.report.test import Test
 from pydantic import ValidationError
 from requests.models import Response
 
-from compliance_suite.constants.constants import (
-    ENDPOINT_TO_MODEL,
-    VERSION_INFO,
-)
+from compliance_suite.constants.constants import ENDPOINT_TO_MODEL
 from compliance_suite.exceptions.compliance_exception import (
     JobValidationException,
     TestFailureException
@@ -43,7 +40,7 @@ class TestRunner():
 
         self.service: str = service
         self.server: str = server
-        self.version: str = VERSION_INFO[version]
+        self.version: str = version
         self.job_data: Any = None
         self.auxiliary_space: Dict = {}     # Dictionary to store the sub-job results
         self.report_test: Any = None        # Test object to store the result

--- a/docs/utility.md
+++ b/docs/utility.md
@@ -67,15 +67,15 @@ env_vars:
 
 The following command line parameters can be run:
 
-| Parameter     | Short Name | Required |Description |
-|---------------|------------|----------|---|
-| --server      | -s         | Yes      |The server URL on which the compliance suite will be run. Format - `https://<url>/`|
-| --version     | -v         | No       |The compliance suite will be run against this TES version. Default - Latest version. Example - `"v1.0"`|
-| --tag         | -t         | No       |Tag for which the compliance suite will be run. It is case insensitive. Default - `"all"` |
-| --output_path | -o         | No       |The output path to store the JSON compliance report |
-| --serve       | NA         | No       |If set, runs a local server and displays the JSON report in HTML web page |
-| --port        | NA         | No       |The port at which the local server is run. Default - 15800 |
-| --uptime      | -u         | No       |The local server duration in seconds. Default - 3600 seconds |
+| Parameter     | Short Name | Required | Description                                                                                     |
+|---------------|------------|----------|-------------------------------------------------------------------------------------------------|
+| --server      | -s         | Yes      | The server URL on which the compliance suite will be run. Format - `https://<url>/`             |
+| --version     | -v         | Yes      | The compliance suite will be run against this TES version. Format - SemVer. Example - `"1.0.0"` |
+| --tag         | -t         | No       | Tag for which the compliance suite will be run. It is case insensitive. Default - `"all"`       |
+| --output_path | -o         | No       | The output path to store the JSON compliance report                                             |
+| --serve       | NA         | No       | If set, runs a local server and displays the JSON report in HTML web page                       |
+| --port        | NA         | No       | The port at which the local server is run. Default - 15800                                      |
+| --uptime      | -u         | No       | The local server duration in seconds. Default - 3600 seconds                                    |
 
 Multiple tags can be set by providing multiple `--tag` or `-t` parameter.
 ```base  
@@ -87,7 +87,7 @@ tes-compliance-suite report --server "https://test.com/" --tag "cancel task" --t
 1. Some examples for command line are:
 ```base  
 tes-compliance-suite report --server "https://test.com/" --tag "all" 
-tes-compliance-suite report --server "https://test.com/" --version "v1.0" --tag "all" --output_path "path/to/store" --serve --port 9090 --uptime 1000
+tes-compliance-suite report --server "https://test.com/" --version "1.0.0" --tag "all" --output_path "path/to/store" --serve --port 9090 --uptime 1000
 ``` 
 
 2.  If the HOME python version is different than 3.8, then absolute path with reference to 3.8 should be used.

--- a/tests/cancel_task.yml
+++ b/tests/cancel_task.yml
@@ -1,6 +1,8 @@
 name: Cancel Tes Task Job
 description: Job to cancel a TES Task
 service: TES
+versions:
+  - 1.0.0
 tags:
   - logical
   - cancel task

--- a/tests/cancel_task_functional.yml
+++ b/tests/cancel_task_functional.yml
@@ -1,6 +1,8 @@
 name: Cancel Tes Task Job
 description: Job to cancel a TES Task
 service: TES
+versions:
+  - 1.0.0
 tags:
   - functional
   - cancel task

--- a/tests/create_task.yml
+++ b/tests/create_task.yml
@@ -1,6 +1,8 @@
 name: Create Tes Task Job
 description: Job to create a new TES Task
 service: TES
+versions:
+  - 1.0.0
 tags:
   - logical
   - create task

--- a/tests/create_task_functional.yml
+++ b/tests/create_task_functional.yml
@@ -1,6 +1,8 @@
 name: Create Tes Task Functional Job
 description: Job to create a new TES Task and test functionality
 service: TES
+versions:
+  - 1.0.0
 tags:
   - functional
   - create task

--- a/tests/get_task_basic.yml
+++ b/tests/get_task_basic.yml
@@ -1,6 +1,8 @@
 name: Get Basic Task Job
 description: Job to retrieve the Basic view of TES Task
 service: TES
+versions:
+  - 1.0.0
 tags:
   - logical
   - get task

--- a/tests/get_task_full.yml
+++ b/tests/get_task_full.yml
@@ -1,6 +1,8 @@
 name: Get Full Task Job
 description: Job to retrieve the Full view of TES Task
 service: TES
+versions:
+  - 1.0.0
 tags:
   - logical
   - get task

--- a/tests/get_task_minimal.yml
+++ b/tests/get_task_minimal.yml
@@ -1,6 +1,8 @@
 name: Get Minimal Task Job
 description: Job to retrieve the Minimal view of TES Task
 service: TES
+versions:
+  - 1.0.0
 tags:
   - logical
   - get task

--- a/tests/list_tasks_basic.yml
+++ b/tests/list_tasks_basic.yml
@@ -1,6 +1,8 @@
 name: List Basic Tasks Job
 description: Job to retrieve the list of Basic view of TES tasks
 service: TES
+versions:
+  - 1.0.0
 tags:
   - logical
   - list tasks

--- a/tests/list_tasks_full.yml
+++ b/tests/list_tasks_full.yml
@@ -1,6 +1,8 @@
 name: List Full Tasks Job
 description: Job to retrieve the list of Full view of TES tasks
 service: TES
+versions:
+  - 1.0.0
 tags:
   - logical
   - list tasks

--- a/tests/list_tasks_minimal.yml
+++ b/tests/list_tasks_minimal.yml
@@ -1,6 +1,8 @@
 name: List Minimal Tasks Job
 description: Job to retrieve the list of Minimal view of TES tasks
 service: TES
+versions:
+  - 1.0.0
 tags:
   - logical
   - list tasks

--- a/tests/service_info.yml
+++ b/tests/service_info.yml
@@ -1,6 +1,8 @@
 name: Service Info Job
 description: Job to retrieve the service info
 service: TES
+versions:
+  - 1.0.0
 tags:
   - logical
   - service info

--- a/tests/template/test_template.yml
+++ b/tests/template/test_template.yml
@@ -1,6 +1,8 @@
 name: <Job Name>
 description: <Job Description>    # Optional
 service: <GA4GH Service Name>   # enum - [TES]
+versions:
+  - <Version>
 tags:
   - <Tag Name>                # Logical - No Polling needed, Functional - Polling needed. Always add 3 tags - Individual tag based on test name, TES endpoint tag and "All" tag
 jobs:

--- a/tests/template/test_template_schema.json
+++ b/tests/template/test_template_schema.json
@@ -18,6 +18,13 @@
         "TES"
       ]
     },
+    "versions": {
+      "type": "array",
+      "description": "The list of TES versions against which the test file can be run",
+      "items": {
+        "type": "string"
+      }
+    },
     "tags": {
       "type": "array",
       "description": "The list of tags which define the test file. Example. Logical - No Polling needed, Functional - Polling needed. Always add 3 tags - Individual tag based on test name, TES endpoint tag and All tag",
@@ -123,6 +130,7 @@
   "required": [
     "name",
     "service",
+    "versions",
     "tags",
     "jobs"
   ]

--- a/tests/template/test_template_schema.json
+++ b/tests/template/test_template_schema.json
@@ -20,7 +20,7 @@
     },
     "versions": {
       "type": "array",
-      "description": "The list of TES versions against which the test file can be run",
+      "description": "The list of API versions against which the test file can be run",
       "items": {
         "type": "string"
       }

--- a/unittests/data/run_job_tests/fail_service_info.yml
+++ b/unittests/data/run_job_tests/fail_service_info.yml
@@ -1,7 +1,8 @@
 name: Service Info Job
 description: Job to retrieve the service info
 service: TES
-#server: https://invalid-url
+versions:
+  - 1.0.0
 tags:
   - logical
   - service info

--- a/unittests/data/run_job_tests/invalid_yaml.yml
+++ b/unittests/data/run_job_tests/invalid_yaml.yml
@@ -2,6 +2,8 @@ Invalid YAML
 name: Service Info Job
 description: Job to retrieve the service info
 service: TES
+versions:
+  - 1.0.0
 tags:
   - logical
   - service info

--- a/unittests/data/run_job_tests/skip_01.yml
+++ b/unittests/data/run_job_tests/skip_01.yml
@@ -1,6 +1,8 @@
 name: Service Info Job
 description: Job to retrieve the service info
 service: TES
+versions:
+  - 1.0.0
 tags:
   - logical
 jobs:

--- a/unittests/data/run_job_tests/success_01.yml
+++ b/unittests/data/run_job_tests/success_01.yml
@@ -1,6 +1,8 @@
 name: Service Info Job
 description: Job to retrieve the service info
 service: TES
+versions:
+  - 1.0.0
 tags:
   - logical
   - service info

--- a/unittests/data/tests/wrong_schema_yaml.yml
+++ b/unittests/data/tests/wrong_schema_yaml.yml
@@ -1,5 +1,7 @@
 description: Job to retrieve the service info
 service: TES
+versions:
+  - 1.0.0
 tags:
   - logical
   - service info

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -33,6 +33,13 @@ class TestJobRunner(unittest.TestCase):
         result = runner.invoke(report, [])
         assert result.exit_code == 1
 
+    def test_report_no_version(self):
+        """ asserts if the application raises Exception if no server is provided"""
+
+        runner = CliRunner()
+        result = runner.invoke(report, ['--server', 'https://test.com/'])
+        assert result.exit_code == 1
+
     @patch.object(JobRunner, "generate_report")
     @patch.object(JobRunner, "run_jobs")
     def test_report_no_tag(self, mock_run_jobs, mock_generate_reports):
@@ -42,7 +49,7 @@ class TestJobRunner(unittest.TestCase):
             mock_run_jobs.return_value = {}
             mock_generate_reports.return_value = '{"test": "test"}'
             runner = CliRunner()
-            result = runner.invoke(report, ['--server', 'https://test.com/'])
+            result = runner.invoke(report, ['--server', 'https://test.com/', '--version', '1.0.0'])
             assert result.exit_code == 0
 
     @patch.object(ReportServer, 'serve_thread')
@@ -56,6 +63,7 @@ class TestJobRunner(unittest.TestCase):
             mock_generate_reports.return_value = '{"test": "test"}'
             mock_report_server.return_value = MagicMock()
             runner = CliRunner()
-            result = runner.invoke(report, ['--server', 'https://test.com/', '--tag', 'All', '--output_path',
-                                            "path/to/output", '--serve', '--port', 9090, '--uptime', 1000])
+            result = runner.invoke(report, ['--server', 'https://test.com/', '--version', '1.0.0', '--tag', 'All',
+                                            '--output_path', "path/to/output", '--serve', '--port', 9090,
+                                            '--uptime', 1000])
             assert result.exit_code == 0

--- a/unittests/test_test_runner.py
+++ b/unittests/test_test_runner.py
@@ -161,7 +161,7 @@ class TestTestRunner(unittest.TestCase):
         mock_validate_response.return_value = {}
         mock_client.return_value = MagicMock()
 
-        test_runner = TestRunner("TES", "test", "1.0.0")
+        test_runner = TestRunner("test", "test", "v1.0")
         job_data = {
             "name": "get_task",
             "description": "test",
@@ -189,7 +189,7 @@ class TestTestRunner(unittest.TestCase):
         resp = MagicMock(status_code=200, text='{"id": "1234"}')
         mock_client.return_value = resp
 
-        test_runner = TestRunner("TES", "test", "1.0.0")
+        test_runner = TestRunner("test", "test", "v1.0")
         job_data = {
             "name": "create_task",
             "description": "test",

--- a/unittests/test_test_runner.py
+++ b/unittests/test_test_runner.py
@@ -161,7 +161,7 @@ class TestTestRunner(unittest.TestCase):
         mock_validate_response.return_value = {}
         mock_client.return_value = MagicMock()
 
-        test_runner = TestRunner("test", "test", "v1.0")
+        test_runner = TestRunner("TES", "test", "1.0.0")
         job_data = {
             "name": "get_task",
             "description": "test",
@@ -189,7 +189,7 @@ class TestTestRunner(unittest.TestCase):
         resp = MagicMock(status_code=200, text='{"id": "1234"}')
         mock_client.return_value = resp
 
-        test_runner = TestRunner("test", "test", "v1.0")
+        test_runner = TestRunner("TES", "test", "1.0.0")
         job_data = {
             "name": "create_task",
             "description": "test",


### PR DESCRIPTION
Creating a separate PR to amend versioning changes as mentioned in #25 since it applies to `v1.0.0` and not only `v1.1.0`.

- Add `versions` field in YAML test files
- Remove the default version in CLI args. It is a required argument now
- Convert SemVer into Major API version in `client.py`