### PR TITLE
feat: reorganize tags

### DIFF
--- a/compliance_suite/utils/test_utils.py
+++ b/compliance_suite/utils/test_utils.py
@@ -23,7 +23,9 @@ def tag_matcher(
         present in the yaml_tags. Otherwise, False.
     """
 
+    # If include_tags is empty, all tests are considered included
+
     return (
         not any(exclude_tag in yaml_tags for exclude_tag in exclude_tags)
-        and any(include_tag in yaml_tags for include_tag in include_tags)
+        and (not include_tags or any(include_tag in yaml_tags for include_tag in include_tags))
     )

--- a/docs/utility.md
+++ b/docs/utility.md
@@ -9,7 +9,7 @@ The report can also be viewed as HTML web page in local server.
 
 ## Installation  
 
-Python 3.8 is the supported Python version and should be installed as an pre-requisite.
+Python 3.8 is the supported Python version and should be installed as a pre-requisite.
 The following steps will guide you to install the suite.
 
 1.  Clone the latest codebase from  [https://github.com/elixir-cloud-aai/tes-compliance-suite](https://github.com/elixir-cloud-aai/tes-compliance-suite)
@@ -91,9 +91,11 @@ The following command line parameters can be run:
 
 ### Tags
 
+- Only letters (a-z, A-Z), digits (0-9) and underscores (_) are allowed.
+
 - Multiple tags can be set by providing multiple `--include-tags` or `--exclude-tags` parameter.
   ```base  
-  tes-compliance-suite report --server "https://test.com/" --include-tags "cancel task" --include-tags "create task" --include-tags "get task"  
+  tes-compliance-suite report --server "https://test.com/" --include-tags tag_1 --include-tags TAG2 --include-tags 123  
   ```  
 
 - A test is run if none of the `--exclude-tags` match any of the Yaml test tags, and at least one of the `--include-tags` is present in the Yaml test tags. Example -  
@@ -102,15 +104,17 @@ The following command line parameters can be run:
   `Test1.yaml` with tags = `["tag1", "tag4"]` will run  
   `Test2.yaml` with tags = `["tag2", "tag3"]` will not run
 
+- If `--include-tags` is not specified, all tests are assumed to be included by default and will be executed.
+
 ## Notes
 
 1. Some examples for command line are:
 ```base  
-tes-compliance-suite report --server "https://test.com/" --include-tags "all" 
-tes-compliance-suite report --server "https://test.com/" --version "1.0.0" --include-tags "all" --output_path "path/to/store" --serve --port 9090 --uptime 1000
+tes-compliance-suite report --server "https://test.com/" --version "1.0.0"
+tes-compliance-suite report --server "https://test.com/" --version "1.0.0" --include-tags "schema_validation_only" --output_path "path/to/store" --serve --port 9090 --uptime 1000
 ``` 
 
-2.  If the HOME python version is different than 3.8, then absolute path with reference to 3.8 should be used.
+2.  If the HOME python version is different from 3.8, then absolute path with reference to 3.8 should be used.
 ```base  
 path/to/python3.8/python setup.py install
 path/to/python3.8/Scripts/tes-compliance-suite report
@@ -118,13 +122,13 @@ path/to/python3.8/Scripts/tes-compliance-suite report
 
 ## Docker image
 
-The project has a [Dockerfile][dockerfile] that creates a ubuntu based container image ready to run tes-compliance-suite. It uses [entrypoint.sh][entrypoint] as an entrypoint, which is most useful if the url of the server changes each time the test suite is run or if only specific tests need to be run. Also, if the server requires basic authentication to connect to, entrypoint.sh can be edited to accept not just the endpoint url, but the username and password as well. 
+The project has a [Dockerfile][dockerfile] that creates an ubuntu based container image ready to run tes-compliance-suite. It uses [entrypoint.sh][entrypoint] as an entrypoint, which is most useful if the url of the server changes each time the test suite is run or if only specific tests need to be run. Also, if the server requires basic authentication to connect to, entrypoint.sh can be edited to accept not just the endpoint url, but the username and password as well. 
 
 ```base  
 http://$tesuser:$tespassword@$teshostname/
 ```
 
-Currently the TES endpoint url in entrypoint.sh will grab the value from an enviormental variable in the image. However, entrypoint.sh gives flexibility to define how that value can be populated. For example, a file can be copied over to the image containing the endpoint url, username and password which could then be read and parsed to pass into tes-compliance suite. Refer to the example below. 
+Currently, the TES endpoint url in entrypoint.sh will grab the value from an environmental variable in the image. However, entrypoint.sh gives flexibility to define how that value can be populated. For example, a file can be copied over to the image containing the endpoint url, username and password which could then be read and parsed to pass into tes-compliance suite. Refer to the example below. 
 
 ```base  
 #!/bin/sh

--- a/tests/cancel_task.yml
+++ b/tests/cancel_task.yml
@@ -1,14 +1,10 @@
-name: Cancel Tes Task Job
 description: Job to cancel a TES Task
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
 tags:
-  - logical
-  - cancel task
-  - cancel task test
-  - all
+  - schema_validation_only
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/cancel_task_functional.yml
+++ b/tests/cancel_task_functional.yml
@@ -1,14 +1,9 @@
-name: Cancel Tes Task Job
 description: Job to cancel a TES Task
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
-tags:
-  - functional
-  - cancel task
-  - cancel task functional test
-  - all
+tags: []
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/create_task.yml
+++ b/tests/create_task.yml
@@ -1,14 +1,10 @@
-name: Create Tes Task Job
 description: Job to create a new TES Task
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
 tags:
-  - logical
-  - create task
-  - create task test
-  - all
+  - schema_validation_only
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/create_task_backend_parameters.yml
+++ b/tests/create_task_backend_parameters.yml
@@ -1,13 +1,9 @@
-name: Create Tes Task Job With Backend Parameters
 description: Job to create a new TES Task with backend parameters
 service: TES
 versions:
   - 1.1.0
 tags:
-  - logical
-  - create task
-  - create task backend parameters test
-  - all
+  - schema_validation_only
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/create_task_backend_parameters_negative.yml
+++ b/tests/create_task_backend_parameters_negative.yml
@@ -1,13 +1,9 @@
-name: Create Tes Task Job With Backend Parameters (Negative case)
 description: Job to create a new TES Task with backend parameters (Negative case)
 service: TES
 versions:
   - 1.1.0
 tags:
-  - logical
-  - create task
-  - create task backend parameters negative test
-  - all
+  - schema_validation_only
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/create_task_functional.yml
+++ b/tests/create_task_functional.yml
@@ -1,14 +1,9 @@
-name: Create Tes Task Functional Job
 description: Job to create a new TES Task and test functionality
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
-tags:
-  - functional
-  - create task
-  - create task functional test
-  - all
+tags: []
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/create_task_ignore_error.yml
+++ b/tests/create_task_ignore_error.yml
@@ -1,13 +1,9 @@
-name: Create Tes Task Job With Ignore Error Flag
 description: Job to create a new TES Task with ignore_error flag
 service: TES
 versions:
   - 1.1.0
 tags:
-  - logical
-  - create task
-  - create task ignore error negative test
-  - all
+  - schema_validation_only
 jobs:
   - name: create_task
     description: Ignore error flag as false, so executor should fail at first command

--- a/tests/create_task_inputs.yml
+++ b/tests/create_task_inputs.yml
@@ -1,14 +1,10 @@
-name: Create Tes Task Job With Inputs
 description: Job to create a new TES Task with inputs
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
 tags:
-  - logical
-  - create task
-  - create task inputs test
-  - all
+  - schema_validation_only
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/create_task_optional_filetype.yml
+++ b/tests/create_task_optional_filetype.yml
@@ -1,13 +1,9 @@
-name: Create Tes Task Job Without Filetypes
 description: Job to create a new TES Task intentionally without input and output filetypes
 service: TES
 versions:
   - 1.1.0
 tags:
-  - logical
-  - create task
-  - create task optional filetypes test
-  - all
+  - schema_validation_only
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/create_task_outputs.yml
+++ b/tests/create_task_outputs.yml
@@ -1,14 +1,10 @@
-name: Create Tes Task Job With Outputs
 description: Job to create a new TES Task with outputs
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
 tags:
-  - logical
-  - create task
-  - create task outputs test
-  - all
+  - schema_validation_only
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/create_task_streamable.yml
+++ b/tests/create_task_streamable.yml
@@ -1,13 +1,9 @@
-name: Create Tes Task Job With Input Streamable Flag
 description: Job to create a new TES Task with streamable flag set in input
 service: TES
 versions:
   - 1.1.0
 tags:
-  - logical
-  - create task
-  - create task streamable test
-  - all
+  - schema_validation_only
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/filter_task_by_name.yml
+++ b/tests/filter_task_by_name.yml
@@ -1,14 +1,9 @@
-name: Filter Task by Name Job
 description: Job to test the filter task by name feature
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
-tags:
-  - logical
-  - filter
-  - filter task by name test
-  - all
+tags: []
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/filter_task_by_state.yml
+++ b/tests/filter_task_by_state.yml
@@ -1,13 +1,8 @@
-name: Filter Task by State Job
 description: Job to test the filter task by state feature
 service: TES
 versions:
   - 1.1.0
-tags:
-  - logical
-  - filter
-  - filter task by state test
-  - all
+tags: []
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/filter_task_by_tag.yml
+++ b/tests/filter_task_by_tag.yml
@@ -1,13 +1,8 @@
-name: Filter Task by Tag Job
 description: Job to test the filter task by tag feature
 service: TES
 versions:
   - 1.1.0
-tags:
-  - logical
-  - filter
-  - filter task by tag test
-  - all
+tags: []
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/get_task_basic.yml
+++ b/tests/get_task_basic.yml
@@ -1,14 +1,10 @@
-name: Get Basic Task Job
 description: Job to retrieve the Basic view of TES Task
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
 tags:
-  - logical
-  - get task
-  - get basic task test
-  - all
+  - schema_validation_only
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/get_task_full.yml
+++ b/tests/get_task_full.yml
@@ -1,14 +1,10 @@
-name: Get Full Task Job
 description: Job to retrieve the Full view of TES Task
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
 tags:
-  - logical
-  - get task
-  - get full task test
-  - all
+  - schema_validation_only
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/get_task_minimal.yml
+++ b/tests/get_task_minimal.yml
@@ -1,14 +1,10 @@
-name: Get Minimal Task Job
 description: Job to retrieve the Minimal view of TES Task
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
 tags:
-  - logical
-  - get task
-  - get minimal task test
-  - all
+  - schema_validation_only
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/list_tasks_basic.yml
+++ b/tests/list_tasks_basic.yml
@@ -1,14 +1,10 @@
-name: List Basic Tasks Job
 description: Job to retrieve the list of Basic view of TES tasks
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
 tags:
-  - logical
-  - list tasks
-  - get list basic tasks test
-  - all
+  - schema_validation_only
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/list_tasks_full.yml
+++ b/tests/list_tasks_full.yml
@@ -1,14 +1,10 @@
-name: List Full Tasks Job
 description: Job to retrieve the list of Full view of TES tasks
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
 tags:
-  - logical
-  - list tasks
-  - get list full tasks test
-  - all
+  - schema_validation_only
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/list_tasks_minimal.yml
+++ b/tests/list_tasks_minimal.yml
@@ -1,14 +1,10 @@
-name: List Minimal Tasks Job
 description: Job to retrieve the list of Minimal view of TES tasks
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
 tags:
-  - logical
-  - list tasks
-  - get list minimal tasks test
-  - all
+  - schema_validation_only
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/list_tasks_page_size.yml
+++ b/tests/list_tasks_page_size.yml
@@ -1,14 +1,9 @@
-name: List Tasks Page Size Job
 description: Job to validate page size in list tasks
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
-tags:
-  - logical
-  - list tasks
-  - get list tasks page size test
-  - all
+tags: []
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/list_tasks_page_token.yml
+++ b/tests/list_tasks_page_token.yml
@@ -1,14 +1,9 @@
-name: List Tasks Page Token Job
 description: Job to validate page token in list tasks
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
-tags:
-  - logical
-  - list tasks
-  - get list tasks page token test
-  - all
+tags: []
 jobs:
   - name: create_task
     description: Create a new TES task

--- a/tests/service_info.yml
+++ b/tests/service_info.yml
@@ -1,14 +1,10 @@
-name: Service Info Job
 description: Job to retrieve the service info
 service: TES
 versions:
   - 1.0.0
   - 1.1.0
 tags:
-  - logical
-  - service info
-  - get service info test
-  - all
+  - schema_validation_only
 jobs:
   - name: service_info
     description: Retrieve the TES server info

--- a/tests/template/test_template.yml
+++ b/tests/template/test_template.yml
@@ -1,4 +1,3 @@
-name: <Job Name>
 description: <Job Description>    # Optional
 service: <GA4GH Service Name>   # enum - [TES]
 versions:

--- a/tests/template/test_template_schema.json
+++ b/tests/template/test_template_schema.json
@@ -3,10 +3,6 @@
   "type": "object",
   "description": "The YAML test file object",
   "properties": {
-    "name": {
-      "type": "string",
-      "description": "The name of the Test file"
-    },
     "description": {
       "type": "string",
       "description": "The description of the Test file"
@@ -30,7 +26,8 @@
       "description": "The list of tags which define the test file. Example. Logical - No Polling needed, Functional - Polling needed. Always add 3 tags - Individual tag based on test name, TES endpoint tag and All tag",
       "items": {
         "type": "string"
-      }
+      },
+      "minItems": 0
     },
     "jobs": {
       "type": "array",
@@ -171,7 +168,6 @@
     }
   },
   "required": [
-    "name",
     "service",
     "versions",
     "tags",

--- a/unittests/data/run_job_tests/fail_service_info.yml
+++ b/unittests/data/run_job_tests/fail_service_info.yml
@@ -1,13 +1,9 @@
-name: Service Info Job
 description: Job to retrieve the service info
 service: TES
 versions:
   - 1.0.0
 tags:
-  - logical
-  - service info
-  - fail service info test
-  - all
+  - schema_validation_only
 jobs:
   - name: service_info
     description: Retrieve the TES server info

--- a/unittests/data/run_job_tests/invalid_yaml.yml
+++ b/unittests/data/run_job_tests/invalid_yaml.yml
@@ -1,14 +1,10 @@
 Invalid YAML
-name: Service Info Job
 description: Job to retrieve the service info
 service: TES
 versions:
   - 1.0.0
 tags:
-  - logical
-  - service info
-  - get service info test
-  - all
+  - schema_validation_only
 jobs:
   - name: service_info
     description: Retrieve the TES server info

--- a/unittests/data/run_job_tests/skip_01.yml
+++ b/unittests/data/run_job_tests/skip_01.yml
@@ -1,10 +1,8 @@
-name: Service Info Job
 description: Job to retrieve the service info
 service: TES
 versions:
   - 1.0.0
-tags:
-  - logical
+tags: []
 jobs:
   - name: service_info
     description: Retrieve the TES server info

--- a/unittests/data/run_job_tests/success_01.yml
+++ b/unittests/data/run_job_tests/success_01.yml
@@ -1,13 +1,9 @@
-name: Service Info Job
 description: Job to retrieve the service info
 service: TES
 versions:
   - 1.0.0
 tags:
-  - logical
-  - service info
-  - get service info test
-  - all
+  - schema_validation_only
 jobs:
   - name: service_info
     description: Retrieve the TES server info

--- a/unittests/data/tests/wrong_schema_yaml.yml
+++ b/unittests/data/tests/wrong_schema_yaml.yml
@@ -1,12 +1,8 @@
 description: Job to retrieve the service info
-service: TES
 versions:
   - 1.0.0
 tags:
-  - logical
-  - service info
-  - get service info test
-  - all
+  - schema_validation_only
 jobs:
   - name: service_info
     description: Retrieve the TES server info

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -26,20 +26,6 @@ class TestJobRunner:
         result = runner.invoke(main)
         assert result.exit_code == 0
 
-    def test_report_no_server(self):
-        """ asserts if the application raises Exception if no server is provided"""
-
-        runner = CliRunner()
-        result = runner.invoke(report, [])
-        assert result.exit_code == 1
-
-    def test_report_no_version(self):
-        """ asserts if the application raises Exception if no server is provided"""
-
-        runner = CliRunner()
-        result = runner.invoke(report, ['--server', TEST_URL])
-        assert result.exit_code == 1
-
     @patch.object(JobRunner, "generate_report")
     @patch.object(JobRunner, "run_jobs")
     def test_report_no_tag(self, mock_run_jobs, mock_generate_reports):
@@ -56,14 +42,22 @@ class TestJobRunner:
     @patch.object(JobRunner, "generate_report")
     @patch.object(JobRunner, "run_jobs")
     def test_report(self, mock_run_jobs, mock_generate_reports, mock_report_server):
-        """ asserts if the application is invoked if a tag is provided"""
+        """ asserts if the application is invoked if the report output path is provided"""
 
         with patch('builtins.open', mock_open()):
             mock_run_jobs.return_value = {}
             mock_generate_reports.return_value = '{"test": "test"}'
             mock_report_server.return_value = MagicMock()
             runner = CliRunner()
-            result = runner.invoke(report, ['--server', TEST_URL, '--version', '1.0.0', '--include-tags', 'All',
+            result = runner.invoke(report, ['--server', TEST_URL, '--version', '1.0.0', '--include-tags', 'test',
                                             '--output_path', "path/to/output", '--serve', '--port', 9090,
                                             '--uptime', 1000])
             assert result.exit_code == 0
+
+    def test_validate_regex_failure(self):
+        """Asserts if the application raises CLI error if invalid regex is provided for tags"""
+
+        runner = CliRunner()
+        result = runner.invoke(report, ['--server', TEST_URL, '--version', '1.0.0', '--exclude-tags', '%%INVALID%%'])
+        assert result.exit_code == 2
+        assert "Only letters (a-z, A-Z), digits (0-9) and underscores (_) are allowed." in result.output

--- a/unittests/test_job_runner.py
+++ b/unittests/test_job_runner.py
@@ -79,5 +79,5 @@ class TestJobRunner:
         mock_os.side_effect = [YAML_TEST_PATH, YAML_TEST_PATH_FAIL, YAML_TEST_PATH_INVALID, YAML_TEST_PATH_SKIP,
                                YAML_TEST_PATH_SUCCESS]
         job_runner_object = JobRunner(TEST_URL, "1.0.0")
-        job_runner_object.set_tags(["all"], [])
+        job_runner_object.set_tags(["schema_validation_only"], [])
         assert job_runner_object.run_jobs() is None


### PR DESCRIPTION
Fixes #40

The following changes were implemented:
- Regex check on CLI args `--include-tags` and `--exclude-tags`
- Mandatory input for CLI args `--server` and `--version`
- Removal of `name` from tests
- Update tags for each test:
Tests that solely perform schema checks now have the tag `schema_validation_only`. To run only these tests, this command should be used `report --server SERVER --version VERSION --include-tags schema_validation_only`. To specifically exclude these schema validation tests and run the remaining tests, the exclusion feature can be utilized: `report --server SERVER --version VERSION --exclude-tags schema_validation_only`
- Condition to run all the tests:
If `--include-tags` is not provided, all tests will be executed by default (subject to exclusion criteria if `--exclude-tags` is provided). Example: `report --server SERVER --version VERSION` will run all available tests. 