### PR TITLE
fix: extra executor present

### DIFF
--- a/tests/create_task_ignore_error.yml
+++ b/tests/create_task_ignore_error.yml
@@ -20,13 +20,6 @@ jobs:
               "ERROR"
             ],
             "ignore_error": false
-          },
-          {
-            "image": "alpine",
-            "command": [
-              "echo",
-              "hello"
-            ]
           }
         ]
       }


### PR DESCRIPTION
The lenght of logs will be equal to the number of executors.

## Summary by Sourcery

Remove redundant executor entry to align log count with the number of executors in tests

Bug Fixes:
- Remove extra executor in test YAML to fix log length mismatch

Tests:
- Update create_task_ignore_error.yml by deleting the unnecessary executor block